### PR TITLE
fix(specify): match trait impl methods to atoms via suffix name matching

### DIFF
--- a/src/commands/specify.rs
+++ b/src/commands/specify.rs
@@ -246,12 +246,7 @@ fn find_matching_atom(func: &FunctionInfo, atoms: &BTreeMap<String, AtomEntry>) 
             let within_tolerance = line_diff <= LINE_TOLERANCE;
 
             if within_span || within_tolerance {
-                // Prefer matches closer to fn_line
-                let effective_diff = if within_span && !within_tolerance {
-                    (func.fn_line as isize - atom_line as isize).unsigned_abs()
-                } else {
-                    line_diff
-                };
+                let effective_diff = line_diff;
 
                 if effective_diff < best_line_diff {
                     best_match = Some(code_name);


### PR DESCRIPTION
## Summary

Fixes #2 — `probe-verus specify` failed to match trait impl methods to their atoms because `find_matching_atom` compared bare identifiers from verus_syn (e.g. `"add"`) against SCIP-enriched qualified names (e.g. `"EdwardsPoint::add"`). Only 26 of 267 functions matched in curve25519-dalek.

- Accept suffix matches where `atom.display_name` ends with `::func.name`, disambiguating same-named methods via existing line proximity logic
- Switch line distance calculation from `spec_text.lines_start` (includes doc comments/attributes) to `fn_line` (the `fn` keyword line) for tighter matching against SCIP definition lines
- Add 7 unit tests covering free functions, inherent/trait impl methods, same-name disambiguation, path mismatches, and doc comment spans

After this fix, `verilib-cli specify` matches **264 of 267** functions (up from 26).

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] New unit tests for `find_matching_atom` cover all matching scenarios
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] End-to-end: `verilib-cli specify ../curve25519-dalek` reports 264 stubs with spec-text


Made with [Cursor](https://cursor.com)