### PR TITLE
Track calls to external (non-workspace) functions in call graph

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,6 +3,8 @@
 //! This module centralizes magic numbers and configuration values
 //! to improve readability and maintainability.
 
+use std::collections::HashSet;
+
 // =============================================================================
 // SCIP Symbol Kinds
 // =============================================================================
@@ -108,6 +110,24 @@ pub const DEFAULT_OUTPUT_DIR: &str = "./output";
 
 /// Expected prefix for SCIP symbols from rust-analyzer/verus-analyzer
 pub const SCIP_SYMBOL_PREFIX: &str = "rust-analyzer cargo ";
+
+/// Suffix pattern that identifies function/method symbols in SCIP notation.
+/// Function symbols end with `().` (e.g., `diffie_hellman().`),
+/// while types end with `#` and fields end with just `.`.
+pub const SCIP_FUNCTION_SUFFIX: &str = "().";
+
+/// Check if a SCIP symbol string represents an external function reference.
+///
+/// External function symbols are those from non-workspace crates that appear
+/// as reference occurrences but not in any document's `symbols` section.
+/// They are detected by their string format: starts with the standard SCIP
+/// prefix and ends with the function suffix pattern `().`.
+#[inline]
+pub fn is_external_function_symbol(symbol: &str, known_symbols: &HashSet<String>) -> bool {
+    !known_symbols.contains(symbol)
+        && symbol.starts_with(SCIP_SYMBOL_PREFIX)
+        && symbol.ends_with(SCIP_FUNCTION_SUFFIX)
+}
 
 /// Prefix for probe-style URIs
 pub const PROBE_URI_PREFIX: &str = "probe:";


### PR DESCRIPTION
## Summary

Fixes #8

- Detect external function symbols by their SCIP symbol string pattern (`rust-analyzer cargo ... ().`) and track them as callees in `build_call_graph`
- Create lightweight stub atoms for external function dependencies so they appear in the atoms dict (with empty `code_path` and zero line ranges)
- Add `is_external_function_symbol` helper in `constants.rs` and `add_external_stubs` public function in `lib.rs`

### Before

`calculate_agreement` in libsignal calls `x25519_dalek::StaticSecret::diffie_hellman`, but atoms.json showed `dependencies: []`.

### After

```json
{
  "probe:libsignal-core/0.1.0/curve/curve25519/...calculate_agreement()": {
    "dependencies": [
      "probe:x25519-dalek/2.0.1/x25519/impl#[StaticSecret]diffie_hellman().",
      "probe:x25519-dalek/2.0.1/x25519/impl#[SharedSecret]as_bytes().",
      "probe:x25519-dalek/2.0.1/x25519/impl#[PublicKey][From<[u8;/32]>]from().",
      "probe:core/.../impl#[&T][Deref]deref()."
    ]
  }
}
```

A stub atom is also created for `diffie_hellman` with empty `code_path` (signaling external).

## Test plan

- [x] All 48 existing unit/integration tests pass
- [x] 9 new unit tests added for `is_external_function_symbol`, `extract_display_name_from_code_name`, and `add_external_stubs`
- [x] Tested on `libsignal_focus_verus_dalek`: 3,084 external stubs created, `calculate_agreement` correctly lists `diffie_hellman` in dependencies
- [x] Clippy clean

Made with [Cursor](https://cursor.com)