### PR TITLE
specs-data: include external_body functions and fix contract duplication

### DIFF
--- a/src/commands/specs_data.rs
+++ b/src/commands/specs_data.rs
@@ -162,7 +162,7 @@ fn extract_math_interpretation(doc_comment: &str) -> String {
 }
 
 /// Compute cross-references: which spec function names appear in a function's
-/// ensures/requires calls.
+/// ensures/requires calls (AST-extracted, not text-based).
 fn compute_referenced_specs(func: &FunctionInfo, spec_names: &HashSet<String>) -> Vec<String> {
     let mut refs: HashSet<String> = HashSet::new();
     for call in func.ensures_calls.iter().chain(func.requires_calls.iter()) {
@@ -170,23 +170,6 @@ fn compute_referenced_specs(func: &FunctionInfo, spec_names: &HashSet<String>) -
             refs.insert(call.clone());
         }
     }
-
-    // Also scan the contract text for spec function references (the Python script does this)
-    if let Some(ref req_text) = func.requires_text {
-        for name in spec_names {
-            if req_text.contains(name.as_str()) {
-                refs.insert(name.clone());
-            }
-        }
-    }
-    if let Some(ref ens_text) = func.ensures_text {
-        for name in spec_names {
-            if ens_text.as_str().contains(name.as_str()) {
-                refs.insert(name.clone());
-            }
-        }
-    }
-
     let mut sorted: Vec<String> = refs.into_iter().collect();
     sorted.sort();
     sorted
@@ -368,6 +351,7 @@ pub fn cmd_specs_data(
     // relative paths from the grandparent.
     let project_prefix = compute_project_prefix(&src_path);
 
+    let re_sig_keyword = Regex::new(r"(?m)^\s*(requires|ensures)\b").unwrap();
     for func in &parsed.functions {
         let file = func.file.as_deref().unwrap_or("");
         let full_file_path = if let Some(ref prefix) = project_prefix {
@@ -468,26 +452,33 @@ pub fn cmd_specs_data(
                 // specs browser to stay consistent with the homepage dashboard.
             }
             DeclKind::Exec => {
-                // Only exec-mode functions with real specs, excluding external_body.
-                // This matches the tracked-csv selection so the specs browser
-                // count is consistent with the homepage dashboard.
-                if !func.specified || func.is_external_body {
+                if !func.specified {
                     continue;
                 }
+
+                let category = if func.is_external_body {
+                    "external"
+                } else {
+                    "tracked"
+                };
 
                 let impl_type = func.impl_type.as_deref().unwrap_or("");
                 let fn_id = make_id(module_path, &func.name, display_name, line);
 
-                // Build contract text from signature + requires + ensures
-                let mut contract_parts: Vec<String> = Vec::new();
-                if let Some(ref sig) = func.signature_text {
-                    contract_parts.push(sig.clone());
-                }
+                // Build contract from signature (truncated before requires/ensures)
+                // plus AST-extracted requires/ensures text for accuracy.
+                let sig = func.signature_text.as_deref().unwrap_or("");
+                let sig_only = if let Some(pos) = re_sig_keyword.find(sig) {
+                    sig[..pos.start()].trim_end()
+                } else {
+                    sig.trim_end()
+                };
+                let mut contract_parts: Vec<&str> = vec![sig_only];
                 if let Some(ref req) = func.requires_text {
-                    contract_parts.push(req.clone());
+                    contract_parts.push(req);
                 }
                 if let Some(ref ens) = func.ensures_text {
-                    contract_parts.push(ens.clone());
+                    contract_parts.push(ens);
                 }
                 let contract = contract_parts.join("\n");
 
@@ -519,7 +510,7 @@ pub fn cmd_specs_data(
                     math_interpretation: math_interp,
                     informal_interpretation: String::new(),
                     github_link,
-                    category: "tracked".to_string(),
+                    category: category.to_string(),
                     is_public,
                     is_libsignal,
                     has_spec,

--- a/src/verus_parser.rs
+++ b/src/verus_parser.rs
@@ -829,10 +829,25 @@ impl FunctionInfoVisitor {
             return None;
         }
 
-        // Phase 1: skip doc comments and attributes to find the fn declaration line.
+        // Phase 1: skip doc comments, attributes, and block comments to find the fn line.
         let mut sig_start = start_idx;
+        let mut in_block_comment = false;
         for line in &lines[start_idx..end_idx] {
             let trimmed = line.trim();
+            if in_block_comment {
+                sig_start += 1;
+                if trimmed.contains("*/") {
+                    in_block_comment = false;
+                }
+                continue;
+            }
+            if trimmed.starts_with("/*") {
+                sig_start += 1;
+                if !trimmed.contains("*/") {
+                    in_block_comment = true;
+                }
+                continue;
+            }
             if trimmed.starts_with("///") || trimmed.starts_with("#[") {
                 sig_start += 1;
             } else {
@@ -840,18 +855,32 @@ impl FunctionInfoVisitor {
             }
         }
 
-        // Phase 2: collect from the fn declaration until the body-opening `{`.
+        // Phase 2: collect from the fn declaration until the body-opening `{`,
+        // preserving indentation relative to the fn line.
+        let base_indent = lines
+            .get(sig_start)
+            .map_or(0, |l| l.len() - l.trim_start().len());
         let mut sig_lines = Vec::new();
         for line in &lines[sig_start..end_idx] {
             if let Some(brace_pos) = line.find('{') {
-                // Include text before the brace on this line
                 let before = line[..brace_pos].trim_end();
                 if !before.is_empty() {
-                    sig_lines.push(before);
+                    let stripped =
+                        if before.len() > base_indent && before[..base_indent].trim().is_empty() {
+                            &before[base_indent..]
+                        } else {
+                            before.trim_start()
+                        };
+                    sig_lines.push(stripped);
                 }
                 break;
             }
-            sig_lines.push(line.trim());
+            let stripped = if line.len() > base_indent && line[..base_indent].trim().is_empty() {
+                line[base_indent..].trim_end()
+            } else {
+                line.trim()
+            };
+            sig_lines.push(stripped);
         }
 
         if sig_lines.is_empty() {


### PR DESCRIPTION
## Include `external_body` functions and improve contract extraction

### Summary

- **Include `external_body` functions in `specs-data` output** — exec functions marked `#[verifier::external_body]` that have `requires`/`ensures` clauses are now emitted with `category: "external"` (previously they were silently skipped)
- **Remove text-based `referenced_specs` scan** — the substring-match fallback (`text.contains(name)`) caused false positives (e.g., spec `p` matching any text containing "p"); now relies solely on AST-extracted call data from `ensures_calls`/`requires_calls`
- **Fix block comments corrupting signatures** — /* ORIGINAL CODE */ and similar block comments inside function bodies were incorrectly included as part of the extracted function signature; they are now skipped during signature extraction
- **Preserve relative indentation in contracts** — signature and contract lines are now dedented relative to the `fn` declaration line, producing cleaner output

### Changed files

| File | What changed |
|---|---|
| `src/commands/specs_data.rs` | Emit `external_body` functions as `category: "external"`; remove text-based ref scan; reconstruct contract from signature (truncated before keywords) + AST-extracted `requires_text`/`ensures_text` |
| `src/verus_parser.rs` | Skip block comments (`/* ... */`) when locating the fn signature start; preserve relative indentation when extracting signature lines |

### Motivation

A spec browser, e.g. [dalek-lite specs browser](https://beneficial-ai-foundation.github.io/dalek-lite/specs.html), needs to display `external_body` functions alongside verified functions, since they represent trust boundaries with explicit contracts. The `referenced_specs` accuracy fix ensures the "Focus referenced specs" feature links to the correct spec functions.