### PR TITLE
fix(scip): remove unused position_encoding fields that break with scip >= v0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ what constitutes a breaking change.
 
 ## [Unreleased]
 
+## [6.10.1] - 2026-06-02
+
+### Fixed
+- Remove unused `position_encoding` field from SCIP `Document` and `SignatureDocumentation` structs; newer `scip` CLI versions (>= v0.7) omit this field from JSON output, causing `extract`/`atomize` to fail with "missing field `position_encoding`"
+
 ## [6.10.0] - 2026-05-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "probe-verus"
-version = "6.10.0"
+version = "6.10.1"
 edition = "2021"
 description = "Probe Verus projects: generate call graph atoms and analyze verification results"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ pub struct Document {
     pub occurrences: Vec<Occurrence>,
     #[serde(default)]
     pub symbols: Vec<Symbol>,
-    pub position_encoding: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -124,7 +123,6 @@ pub struct Symbol {
 pub struct SignatureDocumentation {
     pub language: String,
     pub text: String,
-    pub position_encoding: i32,
 }
 
 /// A call from one function to another, with optional type context for disambiguation


### PR DESCRIPTION
## Summary

- Remove unused `position_encoding` field from `Document` and `SignatureDocumentation` SCIP structs in `src/lib.rs`
- Newer `scip` CLI versions (v0.7+) omit zero-valued protobuf fields from JSON output, causing `extract`/`atomize` to fail with `missing field 'position_encoding'`
- The field was never read by any probe-verus code; serde silently ignores unknown fields, so this is safe with both old and new `scip` versions

## Reproduction

Reproduced locally by upgrading `scip` from v0.6.1 to v0.8.0 and regenerating the SCIP JSON — confirmed the parse failure, then confirmed the fix produces identical output with both versions.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 243/243 pass
- [x] `probe-verus extract` with scip v0.6.1 JSON — success, output identical
- [x] `probe-verus extract` with scip v0.8.0 JSON — success, output identical
- [x] Diff of unified JSON output between old and new scip versions — zero diff (excluding timestamps)

Bump: 6.10.0 → 6.10.1

Made with [Cursor](https://cursor.com)