### PR TITLE
ci: require RELEASE_PAT for tag-release, drop silent GITHUB_TOKEN fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,10 @@ jobs:
           # Use a PAT so the tag push is attributed to a real token and
           # triggers the tag-driven Release workflow. Pushes made with the
           # default GITHUB_TOKEN do not trigger other workflows, which is why
-          # v6.10.2 was tagged but never released. Falls back to GITHUB_TOKEN
-          # if RELEASE_PAT is not configured (tagging still works, but the
-          # Release workflow must then be triggered manually).
-          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          # v6.10.2 and v6.10.3 were tagged but never released. No fallback
+          # on purpose: a missing or expired RELEASE_PAT must fail this job
+          # loudly rather than silently produce a tag that never releases.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Create tag if version changed
         working-directory: probe-verus


### PR DESCRIPTION
Closes #36.

`RELEASE_PAT` is now configured on the repo (added 2026-07-02), so the `tag-release` job no longer needs the `|| secrets.GITHUB_TOKEN` fallback. The fallback was harmful: `GITHUB_TOKEN` tag pushes don't trigger the Release workflow, so a missing or expired PAT silently produced tags that never released (v6.10.2, v6.10.3 — both needed manual tag re-pushes). Without the fallback, a broken PAT fails the checkout loudly. Same approach as probe-lean's auto-tag job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)